### PR TITLE
Format "repository" property in pubspec correctly

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,7 @@ description: >-
   User ListHelper widget and pass call back method to listen scroll event
   using your custom ItemListCallback.
 author: akashMehta-STL <akash.mehta@solutelabs.com>
-repository:
-  - https://github.com/akashMehta-STL/FlutterPaginationHelper.git
+repository: https://github.com/akashMehta-STL/FlutterPaginationHelper.git
 issue_tracker:
   - https://github.com/akashMehta-STL/FlutterPaginationHelper/issues
 homepage: https://github.com/akashMehta-STL/FlutterPaginationHelper.git


### PR DESCRIPTION
We're currently updating `pub.dartlang.org` to support the new `repository` property, and enforce correct formatting.

I would suggest uploading a new version of the package.

I don't think the package has been downloaded a lot just yet :)
So if you would like you can file a quick request to have to old versions of the package deleted:
https://github.com/dart-lang/pub-dartlang-dart/issues
Just file an issue asking to have old versions of your package deleted... and make sure to upload a new version first :)